### PR TITLE
Fixed CMakelists file for Windows usage, added detailed installation guide for windows and linked it with readme.md

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,3 +1,6 @@
+# set(protobuf_INCLUDE_PATH ${protobuf_INCLUDE_PATH} YOUR PATH WHERE YOU CLONED PROTOBUF/protobuf/src/google/protobuf)
+# set(protobuf_LIBRARY_PATH ${protobuf_LIBRARY_PATH} YOUR PATH WHERE YOU CLONED PROTOBUF/protobuf/src)
+
 # Minimum CMake required
 cmake_minimum_required(VERSION 3.5)
 
@@ -9,9 +12,9 @@ find_package(Protobuf REQUIRED)
 
 # check if protobuf was found
 if(PROTOBUF_FOUND)
-    message ("protobuf found")
+	message ("protobuf found")
 else()
-    message (FATAL_ERROR "Cannot find Protobuf")
+	message (FATAL_ERROR "Cannot find Protobuf")
 endif()
 
 # Generate the .h and .cxx files
@@ -20,7 +23,8 @@ set(DNNC_ROOT ${PROJECT_SOURCE_DIR})
 FILE(GLOB onnx_PROTO_FILES onnx/*.proto)
 FILE(GLOB DNNC_SRCS src/*.cc)
 
-set(PROTOBUF_IMPORT_DIRS "${PROJECT_SOURCE_DIR}/onnx")
+set(PROTOBUF_IMPORT_DIRS "${PROJECT_SOURCE_DIR}/python/onnx_info")
+set(onnx_PROTO_FILES "${PROJECT_SOURCE_DIR}/python/onnx_info/onnx.proto")
 
 PROTOBUF_GENERATE_CPP(PROTO_SRCS PROTO_HDRS ${onnx_PROTO_FILES})
 
@@ -32,18 +36,16 @@ message ("PROTO_HDRS = ${PROTO_HDRS}")
 
 # Add an executable
 add_executable(dnnc
-    ${DNNC_SRCS}
-    ${PROTO_SRCS}
-    ${PROTO_HDRS})
+	${DNNC_SRCS}
+	${PROTO_SRCS}
+	${PROTO_HDRS})
 
 target_include_directories(dnnc
-    PUBLIC
-    ${PROTOBUF_INCLUDE_DIRS}
-    ${CMAKE_CURRENT_BINARY_DIR}
-)
+	PUBLIC
+	${PROTOBUF_INCLUDE_DIRS}
+	${CMAKE_CURRENT_BINARY_DIR})
 
 # link the exe against the libraries
 target_link_libraries(dnnc
-    PUBLIC
-    ${PROTOBUF_LIBRARIES}
-)
+	PUBLIC
+	${PROTOBUF_LIBRARIES})

--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ mkdir build && cd build
 cmake ..
 make
 ```
+**Note:** If you are facing issues while installation, **[click here](misc/detailedInstallationGuide.md)** to know if that problem already has a solution.
+
 
 #### 📜 Output
 ```

--- a/misc/detailedInstallationGuide.md
+++ b/misc/detailedInstallationGuide.md
@@ -1,0 +1,66 @@
+# Detailed Installation guide
+
+## Windows
+
+#### Prerequisites:
+* anaconda
+* cmake
+* MinGW
+
+*Why we need this much work? As cmake doesn't work well with protobuf specially in windows.*
+
+#### Step 1:
+* Open **anaconda prompt** in **administrator mode** and run the following command:
+```
+conda install -c anaconda protobuf
+```
+* Open **powershell/cmd** and try to see protoc (proto compiler) version run the following command:
+```
+protoc --version
+```
+It will return something like 3.8.0 (in my case) or 3.9.0 or any other.
+* Go to this **[protobuf Github release](https://github.com/protocolbuffers/protobuf/releases)** and download the specific protobuf release as the same version of the proto compiler you have.
+* Extract the zip and put the **protobuf folder** anywhere you like, but we will be using the downloaded **folder path** later.
+
+#### Step 2:
+* Now look for the directory which is like `YOUR PATH WHERE YOU CLONED PROTOBUF/protobuf/src/google/protobuf`.
+Copy this path and paste it in the `CMakeLists.txt` file in the dnncompiler repository under `protobuf_INCLUDE_PATH`. (You can see it in the 1st line)
+
+> This will set up the path for protobuf for cmake
+
+* Now look for the directory which is like `YOUR PATH WHERE YOU CLONED PROTOBUF/protobuf/src`.
+Copy this path and paste it in the `CMakeLists.txt` file in the dnncompiler repository under `protobuf_LIBRARY_PATH`. (You can see it in the 2nd line)
+
+> This will set up the proto compiler path for protobuf for cmake
+
+
+**Now you should be able to use `cmake ..` without error.**
+
+#### Step 3:
+* To use `make` command in windows, you need MinGW. **[This stackverflow thread](https://stackoverflow.com/questions/23723364/make-is-not-recognized-as-an-internal-or-external-command-operable-program-or/23734705)** has the answers.
+* After installing MinGW, set system path for "C:\MinGW\bin" (Default location for MinGW installation)
+* Then use `MinGW32-make` not `make`.
+
+### So after all of these the steps are:
+
+Inside the folder "dnnCompiler/build":
+
+```
+cmake ..
+MinGW32-make
+```
+
+## Known bugs:
+* When trying MinGW32-make:
+
+```
+Makefile:35: *** missing separator.  Stop.
+```
+
+**Possible reason:** 
+Make command doesn't support `<4 SPACES>` while using indentation. You have to give `<TAB>` in that place.
+
+
+## Contribution:
+
+#### If you find anymore issues and solution, please append them to this file.


### PR DESCRIPTION
* `CMakelists.txt` file needed change as **cmake** can't find protobuf in windows by default.
* Added `detailedInstallationGuide` for users who faces troubles while installation.
* Linked the guide inside the `README.md` file.