### PR TITLE
Added protobuf installation in CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,8 +10,11 @@ find_package(Protobuf REQUIRED)
 # check if protobuf was found
 if(PROTOBUF_FOUND)
     message ("protobuf found")
+
 else()
-    message (FATAL_ERROR "Cannot find Protobuf")
+    message ("Cannot find Protobuf.Installing Protobuf..")
+    execute_process(COMMAND chmod +x ../protobuf_install.sh)
+    execute_process(COMMAND ../protobuf_install.sh)
 endif()
 
 # Generate the .h and .cxx files

--- a/protobuf_install.sh
+++ b/protobuf_install.sh
@@ -1,0 +1,9 @@
+sudo apt-get install autoconf automake libtool curl make g++ unzip
+wget -P ../ https://github.com/protocolbuffers/protobuf/releases/download/v3.6.1/protobuf-cpp-3.6.1.tar.gz
+tar xvzf ../protobuf-cpp-3.6.1.tar.gz
+cd ../protobuf-cpp-3.6.1
+./configure
+make
+make check
+sudo make install
+sudo ldconfig


### PR DESCRIPTION
- Added a bash file which is a recipe to install c++ protobuf complier if it is not already installed - protobuf_install.sh.
-  Script runs during cmake runtime(for Linux like systems).
