### PR TITLE
Added type_check() instead of compare(), used DNNC__EIGEN_ARRAY_MAP

### DIFF
--- a/include/operators/GlobalAveragePool.h
+++ b/include/operators/GlobalAveragePool.h
@@ -35,14 +35,9 @@ template <typename T> class GlobalAveragePool : public baseOperator<T> {
 public:
   GlobalAveragePool(std::string name = "opGlobalAveragePool")
       : baseOperator<T>(opGlobalAveragePool, name) {}
-  /*! Constrain input and output types to float tensors.
-   */
-  static bool compare() {
-    return ((typeid(T) == typeid(float)) || (typeid(T) == typeid(double)));
-  }
   tensor<T> compute(
       tensor<T> a /*!< [float,double]: ND tensor of shape ( NxCxD1xD2…Dk ).*/) {
-    if (!compare())
+    if (!(this->template type_check<float, double>()))
       throw std::invalid_argument(
           "Constrain input and output types to float tensors.");
     size_t axis_left = 1;

--- a/include/operators/GlobalLpPool.h
+++ b/include/operators/GlobalLpPool.h
@@ -47,12 +47,9 @@ public:
     }
     return false;
   }
-  static bool compare() {
-    return ((typeid(T) == typeid(float)) || (typeid(T) == typeid(double)));
-  }
   tensor<T> compute(
       tensor<T> a /*!< [float,double]: ND tensor of shape ( NxCxD1xD2…Dk ).*/) {
-    if (!compare())
+    if (!(this->template type_check<float, double>()))
       throw std::invalid_argument(
           "Constrain input and output types to float tensors.");
     size_t axis_left = 1;

--- a/include/operators/GlobalMaxPool.h
+++ b/include/operators/GlobalMaxPool.h
@@ -32,11 +32,8 @@ template <typename T> class GlobalMaxPool : public baseOperator<T> {
 public:
   GlobalMaxPool(std::string name = "opGlobalMaxPool")
       : baseOperator<T>(opGlobalMaxPool, name) {}
-  static bool compare() {
-    return ((typeid(T) == typeid(float)) || (typeid(T) == typeid(double)));
-  }
   tensor<T> compute(tensor<T> a) {
-    if (!compare())
+    if (!(this->template type_check<float, double>()))
       throw std::invalid_argument(
           "Constrain input and output types to float tensors.");
     size_t axis_left = 1;
@@ -47,7 +44,6 @@ public:
     std::vector<size_t> shape{a.shape()[0], a.shape()[1], axis_left};
     a.reshape(shape);
     shape.pop_back();
-    std::cout << a.rank() << "\n";
     for (int i = 2; i < int(rank); i++) {
       shape.push_back(1);
     }

--- a/include/operators/Greater.h
+++ b/include/operators/Greater.h
@@ -37,18 +37,16 @@ public:
   Greater(std::string name = "opGreater") : baseOperator<T>(opGreater, name) {}
 
   tensor<bool>
-  compute(tensor<T> a /*!< First input operand for the logical operator.*/,
-          tensor<T> b /*!< Second input operand for the logical operator.*/) {
+  compute(tensor<T> &a /*!< First input operand for the logical operator.*/,
+          tensor<T> &b /*!< Second input operand for the logical operator.*/) {
     std::vector<DIMENSION> resultShape = binaryBroadcastReShape(a, b);
     tensor<bool> result(resultShape);
 
     if (a.shape() != b.shape())
       throw std::invalid_argument(
           "tensor dimenions not appropriate for Greater operator.");
-    a.flatteninplace();
-    b.flatteninplace();
-    DNNC_EIGEN_VECTOR(eigenVectorA, a);
-    DNNC_EIGEN_VECTOR(eigenVectorB, b);
+    DNNC_EIGEN_ARRAY_MAP(eigenVectorA, a);
+    DNNC_EIGEN_ARRAY_MAP(eigenVectorB, b);
     DNNC_EIGEN_VECTOR_CTOR(bool) eResult;
     eResult.array() = eigenVectorA.array() > eigenVectorB.array();
     result.load(eResult.data());

--- a/include/operators/HardSigmoid.h
+++ b/include/operators/HardSigmoid.h
@@ -24,7 +24,6 @@
 #pragma once
 #include "operators/baseOperator.h"
 #include <string>
-#include <typeinfo>
 using namespace Eigen;
 
 namespace dnnc {
@@ -43,11 +42,6 @@ public:
     this->alpha = alpha;
     this->beta = beta;
   }
-  /*! Constrain input and output types to float tensors.
-   */
-  static bool compare() {
-    return ((typeid(T) == typeid(float)) || (typeid(T) == typeid(double)));
-  }
   bool getAttribute(OPATTR attrName, float &obj) {
     if (attrName == attr_alpha) {
       obj = alpha;
@@ -64,14 +58,14 @@ public:
     temp = (0 > temp) ? 0 : temp;
     return temp;
   }
-  tensor<T> compute(tensor<T> a /*!<[float,double]: ND tensor*/) {
-    if (!compare())
+  tensor<T> compute(tensor<T> &a /*!<[float,double]: ND tensor*/) {
+
+    if (!(this->template type_check<float, double>()))
       throw std::invalid_argument(
           "Constrain input and output types to float tensors.");
     tensor<T> result(a.shape(), a.name());
     // max(0, min(1, alpha * x + beta))
-    a.flatteninplace();
-    DNNC_EIGEN_VECTOR(eigenVector, a);
+    DNNC_EIGEN_ARRAY_MAP(eigenVector, a);
     DNNC_EIGEN_VECTOR_CTOR(T) eResult;
     auto c0 = std::bind(Hard_Sigmoid, std::placeholders::_1, alpha, beta);
     eResult.array() = eigenVector.array().unaryExpr(c0);

--- a/include/operators/Hardmax.h
+++ b/include/operators/Hardmax.h
@@ -52,13 +52,8 @@ public:
     }
     return false;
   }
-  /*! Constrain input and output types to float tensors.
-   */
-  static bool compare() {
-    return ((typeid(T) == typeid(float)) || (typeid(T) == typeid(double)));
-  }
   tensor<T> compute(tensor<T> a/*< The input tensor that will be coerced into a 2D matrix of size (NxD) as described in operator definition*/) {
-    if (!compare())
+    if (!(this->template type_check<float, double>()))
       throw std::invalid_argument(
           "Constrain input and output types to float tensors.");
     if (axis >= int(a.rank()))

--- a/include/operators/InstanceNormalization.h
+++ b/include/operators/InstanceNormalization.h
@@ -61,11 +61,6 @@ public:
       : baseOperator<T>(opInstanceNormalization) {
     this->epsilon = epsilon;
   }
-  /*! Constrain input and output types to float tensors.
-   */
-  static bool compare() {
-    return ((typeid(T) == typeid(float)) || (typeid(T) == typeid(double)));
-  }
   bool getAttribute(OPATTR attrName, float &obj) {
     if (attrName == attr_epsilon) {
       obj = epsilon;
@@ -78,7 +73,7 @@ public:
               input /*!< [float,double]: ND tensor of shape ( NxCxD1xD2…Dk ).*/,
           tensor<T> &scale /*!<  1D vector of dimension C.*/,
           tensor<T> &B /*!< : 1D vector of dimension C.*/) {
-    if (!compare())
+    if (!(this->template type_check<float, double>()))
       throw std::invalid_argument(
           "Constrain input and output types to float tensors.");
 

--- a/include/operators/IsInf.h
+++ b/include/operators/IsInf.h
@@ -57,11 +57,6 @@ public:
     }
     return false;
   }
-  /*! Constrain input and output types to float tensors.
-   */
-  static bool compare() {
-    return ((typeid(T) == typeid(float)) || (typeid(T) == typeid(double)));
-  }
 
   static bool Is_INF(T x, int detect_negative, int detect_positive) {
     if (std::isinf(x)) {
@@ -76,7 +71,7 @@ public:
   }
   // NOT GOOD to return by value
   tensor<bool> compute(tensor<T> &a) {
-    if (!compare())
+    if (!(this->template type_check<float, double>()))
       throw std::invalid_argument(
           "Constrain input and output types to float tensors.");
     tensor<bool> result(a.shape(), a.name());

--- a/include/operators/IsNaN.h
+++ b/include/operators/IsNaN.h
@@ -32,19 +32,13 @@ namespace dnnc {
 template <typename T> class IsNaN : public baseOperator<T> {
 public:
   IsNaN(std::string name = "opIsNaN") : baseOperator<T>(opIsNaN, name) {}
-  /*! Constrain input and output types to float tensors.
-   */
-  static bool compare() {
-    return ((typeid(T) == typeid(float)) || (typeid(T) == typeid(double)));
-  }
-  // NOT GOOD to return by value
-  tensor<bool> compute(tensor<T> a) {
-    if (!compare())
+
+  tensor<bool> compute(tensor<T> &a) {
+    if (!(this->template type_check<float, double>()))
       throw std::invalid_argument(
           "Constrain input and output types to float tensors.");
     tensor<bool> result(a.shape(), a.name());
-    a.flatteninplace();
-    DNNC_EIGEN_VECTOR(eigenVector, a);
+    DNNC_EIGEN_ARRAY_MAP(eigenVector, a);
     DNNC_EIGEN_VECTOR_CTOR(bool) eResult;
     eResult.array() = eigenVector.array().isNaN();
 

--- a/include/operators/LRN.h
+++ b/include/operators/LRN.h
@@ -57,10 +57,6 @@ public:
     this->bias = bias;
     this->size = size;
   }
-
-  static bool compare() {
-    return ((typeid(T) == typeid(float)) || (typeid(T) == typeid(double)));
-  }
   bool getAttribute(OPATTR attrName, float &obj) {
     if (attrName == attr_alpha) {
       obj = alpha;
@@ -86,7 +82,7 @@ public:
     C is the number of channels, and H and W are the height and the width of the data.
     For non image case, the dimensions are in the form of  \f$(N * C * D1 * D2* ...* Dn)\f$,
      where N is the batch size.*/) {
-    if (!compare())
+    if (!(this->template type_check<float, double>()))
       throw std::invalid_argument(
           "Constrain input and output types to float tensors.");
 

--- a/include/operators/LeakyRelu.h
+++ b/include/operators/LeakyRelu.h
@@ -48,12 +48,6 @@ public:
     }
     return false;
   }
-  /*! Constrain input and output types to float tensors.
-   */
-  static bool compare() {
-    return ((typeid(T) == typeid(float)) || (typeid(T) == typeid(double)));
-  }
-
   static T Leaky_Relu(T x, float alpha) {
     if (x < 0)
       return T(alpha * x);
@@ -61,13 +55,12 @@ public:
       return x;
   }
 
-  tensor<T> compute(tensor<T> a /*!<[float,double]: ND tensor*/) {
-    if (!compare())
+  tensor<T> compute(tensor<T> &a /*!<[float,double]: ND tensor*/) {
+    if (!(this->template type_check<float, double>()))
       throw std::invalid_argument(
           "Constrain input and output types to float tensors.");
     tensor<T> result(a.shape(), a.name());
-    a.flatteninplace();
-    DNNC_EIGEN_VECTOR(eigenVector, a);
+    DNNC_EIGEN_ARRAY_MAP(eigenVector, a);
     DNNC_EIGEN_VECTOR_CTOR(T) eResult;
     auto c0 = std::bind(Leaky_Relu, std::placeholders::_1, alpha);
     eResult.array() = eigenVector.array().unaryExpr(c0);

--- a/include/operators/baseOperator.h
+++ b/include/operators/baseOperator.h
@@ -21,8 +21,11 @@
 // https://github.com/ai-techsystems/dnnCompiler
 //
 #pragma once
+#include "core/broadcast.h"
 #include "operators/macros.h"
 #include <memory>
+#include <typeindex>
+#include <typeinfo>
 #include <vector>
 
 // we're forced to include tensor.h here, because of limitation on
@@ -274,6 +277,21 @@ public:
   template <typename attrType>
   bool getAttribute(OPATTR attrName, attrType &obj);
 
+  /*!< Constrain input and output types.*/
+  template <typename... Types> bool type_check() {
+    std::vector<std::type_index> allowed_types;
+    allowed_types.insert(allowed_types.end(), {typeid(Types)...});
+    bool checker = false;
+    for (size_t i = 0; i < allowed_types.size(); i++) {
+      checker = (allowed_types[i] == std::type_index(typeid(T)));
+      if (checker)
+        break;
+    }
+    return checker;
+  }
+  /*!<
+   \return Returns true if T is one of the types specified
+   */
   void compute(void);
   tensor<T> compute(tensor<T> in1);
   tensor<T> compute(tensor<T> &in1);

--- a/src/operators/Greater.cpp
+++ b/src/operators/Greater.cpp
@@ -36,8 +36,8 @@ int main() {
   a.load(d1);
   tensor<int> b(2, 1, 3);
   b.load(d2);
-  std::cout << a;
-  std::cout << b;
+  std::cout << a << "\n";
+  std::cout << b << "\n";
   Greater<int> m("localOpName");
   auto result = m.compute(a, b);
   std::cout << result;

--- a/src/operators/HardSigmoid.cpp
+++ b/src/operators/HardSigmoid.cpp
@@ -42,7 +42,6 @@ int main() {
 
   std::cout << result;
   std::cout << "\n";
-
   return 0;
 }
 


### PR DESCRIPTION
Implemented general type checking in baseOperator.h
Instead of !compare()
use
!(this->template type_check<float,double>())

You can put any type in between <..>.
This will compare the types between <...> with 'T' and return true if T is one of them.
Also please delete your compare implementation.